### PR TITLE
Use db-image from GHCR instead of DockerHub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       USERS_FILE: "config/users"
 
   mariadb:
-    image: hathitrust/db-image
+    image: ghcr.io/hathitrust/db-image
     restart: always
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 1 


### PR DESCRIPTION
I'm trying to remove remaining references to DockerHub (rather than GHCR). I don't think there are any production dependencies, just test, so this should be safe.